### PR TITLE
Return an error, if NULL is not found

### DIFF
--- a/handshake_v10.go
+++ b/handshake_v10.go
@@ -36,6 +36,9 @@ func ReadHandshakeV10(stream *Stream) (HandshakeV10, error) {
 	pos += 1
 
 	null := bytes.IndexByte(data[pos:], 0x00)
+	if null == -1 {
+		return HandshakeV10{}, errors.New("mysqlproto: expected 0x00: " + string(data))
+	}
 	packet.ServerVersion = string(data[pos : pos+null])
 	pos += null + 1 // skip null terminator
 


### PR DESCRIPTION
Sometimes we have the following panic:

```
runtime error: slice bounds out of range [1:0]
  "runtime.goPanicSliceB",
  "handshake_v10.go:39 github.com/pubnative/mysqlproto-go.ReadHandshakeV10",
  "conn.go:22 github.com/pubnative/mysqlproto-go.ConnectPlainHandshake",
```

I believe this happens when `bytes.IndexByte` can't find 0x00 and returns -1.
I'm not quite sure why it's the case, so having an error with the packet
payload would help to debug it.